### PR TITLE
Changes the API to accept an arbitrary message.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,16 @@
 
 [![Build Status](https://travis-ci.org/fxbox/registration_server.svg?branch=master)](https://travis-ci.org/fxbox/registration_server)
 
-This server listen on port 4242 and let you register devices from your home network and discover them later on.
+This server exposes a http(s) API that lets you post messages from your home network and discover them later on.
+
+Usage:
+
+```bash
+cargo run -- -host 0.0.0.0 --port 4242 --cert-dir /etc/letsencrypt/live/knilxof.org
 
 ## Urls
 
 Two endpoints are provided:
 
-1. /register?ip=XXX will register `ip` as a local ip associated to your current network.
-2. /ping will return a json representation of the endpoints that are bound to the current public ip of the request.
+1. /register?message=XXX will publish `message` to other clients who also connect from the same outgoing IP address as you.
+2. /ping will return a json representation of the messages that are published from the same outgoing IP address.

--- a/client/main.js
+++ b/client/main.js
@@ -35,8 +35,8 @@ function doDiscovery() {
       content = "<p>No FoxBox available!</p>";
     } else {
       data.forEach(item => {
-        content += `<p>FoxBox found at ${item.local_ip}</p>`;
-        loadJSON("GET", `http://${item.local_ip}:3000/services/list.json`).then(list => {
+        content += `<p>FoxBox found at ${item.domain}</p>`;
+        loadJSON("GET", `http://local.${item.domain}:3000/services/list.json`).then(list => {
           console.log("Service list: " + JSON.stringify(list));
           let html = "<ul>";
           for (let s in list) {

--- a/src/db.rs
+++ b/src/db.rs
@@ -18,8 +18,8 @@ fn get_db_environment() -> String {
 #[derive(RustcEncodable, Debug)]
 pub struct Record {
     pub public_ip: String,
-    pub local_ip: String,
-    pub tunnel_url: Option<String>,
+    pub domain:    String,
+    pub tunnel_configured: bool,
     pub timestamp: i64 // i64 because of the database type.
 }
 
@@ -30,7 +30,7 @@ fn escape(string: &str) -> String {
 
 pub enum FindFilter {
     PublicIp(String),
-    PublicAndLocalIp(String, String)
+    PublicIpAndFingerprintDomain(String, String)
 }
 
 pub struct Db {
@@ -46,8 +46,8 @@ impl Db {
         let connection = Connection::open(get_db_environment()).unwrap();
         connection.execute("CREATE TABLE IF NOT EXISTS boxes (
                 public_ip TEXT NOT NULL,
-                local_ip  TEXT NOT NULL,
-                tunnel_url TEXT,
+                domain TEXT,
+                tunnel_configured INTEGER,
                 timestamp INTEGER
             )", &[]).unwrap();
 
@@ -80,11 +80,11 @@ impl Db {
                 );
                 try!(stmt.query(&[&escape(&public_ip)]))
             },
-            FindFilter::PublicAndLocalIp(public_ip, local_ip) => {
+            FindFilter::PublicIpAndFingerprintDomain(public_ip, domain) => {
                 stmt = try!(
-                    self.connection.prepare("SELECT * FROM boxes WHERE (public_ip=$1 and local_ip=$2)")
+                    self.connection.prepare("SELECT * FROM boxes WHERE (public_ip=$1 and domain=$2)")
                 );
-                try!(stmt.query(&[&escape(&public_ip), &escape(&local_ip)]))
+                try!(stmt.query(&[&escape(&public_ip), &escape(&domain)]))
             }
         };
 
@@ -93,8 +93,8 @@ impl Db {
             let row = try!(result_row);
             records.push(Record {
                 public_ip: row.get(0),
-                local_ip: row.get(1),
-                tunnel_url: row.get(2),
+                domain: row.get(1),
+                tunnel_configured: row.get(2),
                 timestamp: row.get(3)
             });
         }
@@ -103,17 +103,18 @@ impl Db {
 
     pub fn update(&self, record: Record) -> rusqlite::Result<i32> {
         self.connection.execute("UPDATE boxes
-            SET public_ip=$1, local_ip=$2, tunnel_url=$3, timestamp=$4
-            WHERE (public_ip=$5 AND local_ip=$6)",
-            &[&record.public_ip, &record.local_ip, &record.tunnel_url,
-              &record.timestamp, &record.public_ip, &record.local_ip])
+            SET public_ip=$1, domain=$2, tunnel_configured=$3 timestamp=$4
+            WHERE (public_ip=$5 AND domain=$6)",
+            &[&record.public_ip, &record.domain, &bool_as_int(&record.tunnel_configured), &record.timestamp,
+              &record.public_ip, &record.domain])
     }
 
     pub fn add(&self, record: Record) -> rusqlite::Result<i32> {
         self.connection.execute("INSERT INTO boxes
-            (public_ip, local_ip, tunnel_url, timestamp)
+            (public_ip, domain, tunnel_configured, timestamp)
             VALUES ($1, $2, $3, $4)",
-            &[&record.public_ip, &record.local_ip, &record.tunnel_url,
+            &[&record.public_ip, &record.domain,
+            &bool_as_int(&record.tunnel_configured),
             &record.timestamp])
     }
 
@@ -122,12 +123,17 @@ impl Db {
     }
 }
 
+// Used to store a boolean as an INTEGER in sqlite
+fn bool_as_int(value: &bool) -> i32 {
+    if *value { 1 } else { 0 }
+}
+
 #[test]
 fn test_db() {
     let db = Db::new();
 
     // Look for a record, but the db is empty.
-    match db.find(FindFilter::PublicAndLocalIp("127.0.0.1".to_owned(), "10.0.0.1".to_owned())) {
+    match db.find(FindFilter::PublicIpAndFingerprintDomain("127.0.0.1".to_owned(), "<fingerprint>.knilxof.org".to_owned())) {
         Ok(vec) => { assert!(vec.is_empty()); },
         Err(err) => { println!("Unexpected error: {}", err); assert!(false); }
     }
@@ -135,8 +141,8 @@ fn test_db() {
 
     let mut r = Record {
         public_ip: "127.0.0.1".to_owned(),
-        local_ip: "10.0.0.1".to_owned(),
-        tunnel_url: Some("https://foo.bar.com".to_owned()),
+        domain: "<fingerprint>.knilxof.org".to_owned(),
+        tunnel_configured: false,
         timestamp: now
     };
 
@@ -146,7 +152,7 @@ fn test_db() {
         Err(err) => { println!("Unexpected error: {}", err); assert!(false); }
     }
     // Check that we find it.
-    match db.find(FindFilter::PublicAndLocalIp("127.0.0.1".to_owned(), "10.0.0.1".to_owned())) {
+    match db.find(FindFilter::PublicIpAndFingerprintDomain("127.0.0.1".to_owned(), "<fingerprint>.knilxof.org".to_owned())) {
         Ok(records) => {
             assert_eq!(records.len(), 1);
             assert_eq!(records[0].timestamp, now);
@@ -157,8 +163,8 @@ fn test_db() {
     // Add another record with the same public IP, but a different local one.
     r = Record {
         public_ip: "127.0.0.1".to_owned(),
-        local_ip: "10.0.0.2".to_owned(),
-        tunnel_url: None,
+        domain: "<another_fingerprint>.knilxof.org".to_owned(),
+        tunnel_configured: true,
         timestamp: now
     };
     match db.add(r) {
@@ -170,10 +176,10 @@ fn test_db() {
     match db.find(FindFilter::PublicIp("127.0.0.1".to_owned())) {
         Ok(records) => {
             assert_eq!(records.len(), 2);
-            assert_eq!(records[0].local_ip, "10.0.0.1");
-            assert_eq!(records[1].local_ip, "10.0.0.2");
-            assert_eq!(records[0].tunnel_url.clone().unwrap(), "https://foo.bar.com");
-            assert_eq!(records[1].tunnel_url, None);
+            assert_eq!(records[0].domain, "<fingerprint>.knilxof.org");
+            assert_eq!(records[0].tunnel_configured, false);
+            assert_eq!(records[1].domain, "<another_fingerprint>.knilxof.org");
+            assert_eq!(records[1].tunnel_configured, true);
         },
         Err(err) => { println!("Unexpected error: {}", err); assert!(false); }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -53,8 +53,8 @@ pub fn from_decoder_error(error: json::DecoderError) -> IronResult<Response> {
     match error {
         json::DecoderError::MissingFieldError(field) => {
             let errno = match field.as_ref() {
-                "local_ip" => 100,
-                "tunnel_url" => 101,
+                "domain" => 100,
+                "tunnel_configured" => 101,
                 _ => 400
             };
             EndpointError::with(status::BadRequest, errno)

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,7 @@
 
 /// Simple server that manages foxbox registrations.
 /// Two end points are available:
-/// POST /register => to register a match between public IP, local IP
-///                   and tunnel URL.
+/// POST /register => to register a match between public IP and mesage.
 /// GET /ping => to get the list of public IP matches.
 ///
 /// Boxes are supposed to register themselves at regular intervals so we


### PR DESCRIPTION
Now accepts only a domain containing a fingerprint the local and remote endpoints are then to be derived from this domain.  local.<domain> and remote.<domain> for example.

In the near future, we will verify that the client request certificate used to POST entries is using the fingerprint in the POSTed domain.
